### PR TITLE
Support for traceparent correlation header

### DIFF
--- a/server/mq/mq.go
+++ b/server/mq/mq.go
@@ -3,7 +3,7 @@ package mq
 import "github.com/resgateio/resgate/server/reserr"
 
 // Response sends a response to the messaging system
-type Response func(subj string, payload []byte, err error)
+type Response func(subj string, payload []byte, responseHeaders map[string][]string, err error)
 
 // Unsubscriber is the interface that wraps the basic Unsubscribe method
 type Unsubscriber interface {
@@ -18,7 +18,7 @@ type Client interface {
 
 	// SendRequest sends an asynchronous request on a subject, expecting the Response
 	// callback to be called once on a separate go routine.
-	SendRequest(subject string, payload []byte, cb Response)
+	SendRequest(subject string, payload []byte, cb Response, requestHeaders map[string][]string)
 
 	// Subscribe to all events on a resource namespace.
 	// The namespace has the format "event."+resource

--- a/server/rescache/rescache.go
+++ b/server/rescache/rescache.go
@@ -39,7 +39,7 @@ type Cache struct {
 // Subscriber interface represents a subscription made on a client connection
 type Subscriber interface {
 	CID() string
-	Loaded(resourceSub *ResourceSubscription, err error)
+	Loaded(resourceSub *ResourceSubscription, responseHeaders map[string][]string, err error)
 	Event(event *ResourceEvent)
 	ResourceName() string
 	ResourceQuery() string
@@ -99,7 +99,7 @@ func (c *Cache) Start() error {
 		go c.startWorker(inCh)
 	}
 
-	resetSub, err := c.mq.Subscribe("system", func(subj string, payload []byte, _ error) {
+	resetSub, err := c.mq.Subscribe("system", func(subj string, payload []byte, responseHeaders map[string][]string, _ error) {
 		ev := subj[7:]
 		switch ev {
 		case "reset":
@@ -131,14 +131,14 @@ func (c *Cache) Errorf(format string, v ...interface{}) {
 
 // Subscribe fetches a resource from the cache, and if it is
 // not cached, starts subscribing to the resource and sends a get request
-func (c *Cache) Subscribe(sub Subscriber, t *Throttle) {
+func (c *Cache) Subscribe(sub Subscriber, t *Throttle, requestHeaders map[string][]string) {
 	eventSub, err := c.getSubscription(sub.ResourceName(), true)
 	if err != nil {
-		sub.Loaded(nil, err)
+		sub.Loaded(nil, nil, err)
 		return
 	}
 
-	eventSub.addSubscriber(sub, t)
+	eventSub.addSubscriber(sub, t, requestHeaders)
 }
 
 // Access sends an access request
@@ -154,7 +154,7 @@ func (c *Cache) Access(sub Subscriber, token interface{}, callback func(access *
 
 		access, rerr := codec.DecodeAccessResponse(data)
 		callback(&Access{AccessResult: access, Error: rerr})
-	})
+	}, nil)
 }
 
 // Call sends a method call request
@@ -183,7 +183,7 @@ func (c *Cache) Call(req codec.Requester, rname, query, action string, token, pa
 		}
 
 		callback(codec.DecodeCallResponse(data))
-	})
+	}, nil)
 }
 
 // Auth sends an auth method call
@@ -197,30 +197,30 @@ func (c *Cache) Auth(req codec.AuthRequester, rname, query, action string, token
 		}
 
 		callback(codec.DecodeCallResponse(data))
-	})
+	}, nil)
 }
 
 // CustomAuth sends an auth method call to a custom subject
 func (c *Cache) CustomAuth(req codec.AuthRequester, subj, query string, token, params interface{}, callback func(result json.RawMessage, rid string, err error)) {
 	payload := codec.CreateAuthRequest(params, req, query, token)
-	c.mq.SendRequest(subj, payload, func(_ string, data []byte, err error) {
+	c.mq.SendRequest(subj, payload, func(_ string, data []byte, responseHeaders map[string][]string, err error) {
 		if err != nil {
 			callback(nil, "", err)
 			return
 		}
 
 		callback(codec.DecodeCallResponse(data))
-	})
+	}, nil)
 }
 
-func (c *Cache) sendRequest(rname, subj string, payload []byte, cb func(data []byte, err error)) {
+func (c *Cache) sendRequest(rname, subj string, payload []byte, cb func(data []byte, err error), requestHeaders map[string][]string) {
 	eventSub, _ := c.getSubscription(rname, false)
-	c.mq.SendRequest(subj, payload, func(_ string, data []byte, err error) {
+	c.mq.SendRequest(subj, payload, func(_ string, data []byte, responseHeaders map[string][]string, err error) {
 		eventSub.Enqueue(func() {
 			cb(data, err)
 			eventSub.removeCount(1)
 		})
-	})
+	}, requestHeaders)
 }
 
 // AddConn adds a connection listening to events such as system token reset
@@ -263,7 +263,7 @@ func (c *Cache) getSubscription(name string, subscribe bool) (*EventSubscription
 	}
 
 	if subscribe && eventSub.mqSub == nil {
-		mqSub, err := c.mq.Subscribe("event."+name, func(subj string, payload []byte, _ error) {
+		mqSub, err := c.mq.Subscribe("event."+name, func(subj string, payload []byte, responseHeaders map[string][]string, _ error) {
 			eventSub.enqueueEvent(subj, payload)
 		})
 		if err != nil {

--- a/server/subscription.go
+++ b/server/subscription.go
@@ -20,7 +20,7 @@ type ConnSubscriber interface {
 	Errorf(format string, v ...interface{})
 	CID() string
 	Token() json.RawMessage
-	Subscribe(rid string, direct bool, throttle *rescache.Throttle) (*Subscription, error)
+	Subscribe(rid string, direct bool, throttle *rescache.Throttle, headers map[string][]string) (*Subscription, error)
 	Unsubscribe(sub *Subscription, direct bool, count int, tryDelete bool)
 	Access(sub *Subscription, callback func(*rescache.Access))
 	Send(data []byte)
@@ -54,6 +54,7 @@ type Subscription struct {
 	accessCallbacks []func(*rescache.Access)
 	flags           uint8
 	throttle        *rescache.Throttle
+	traceparent     string
 
 	// Protected by conn
 	direct   int // Number of direct subscriptions
@@ -185,7 +186,7 @@ func (s *Subscription) Ref(rid string) *Subscription {
 // Loaded is called by rescache when the subscribed resource has been loaded.
 // If the resource was successfully loaded, err will be nil. If an error occurred
 // when loading the resource, resourceSub will be nil, and err will be the error.
-func (s *Subscription) Loaded(resourceSub *rescache.ResourceSubscription, err error) {
+func (s *Subscription) Loaded(resourceSub *rescache.ResourceSubscription, responseHeaders map[string][]string, err error) {
 	if !s.c.Enqueue(func() {
 		if err != nil {
 			s.err = err
@@ -196,6 +197,12 @@ func (s *Subscription) Loaded(resourceSub *rescache.ResourceSubscription, err er
 		if s.state == stateDisposed {
 			resourceSub.Unsubscribe(s)
 			return
+		}
+
+		// We check if we received a traceparent header in the response. If we did, we set it on the subscription.
+		val, ok := responseHeaders["traceparent"]
+		if ok && len(val) > 0 && s.traceparent == "" {
+			s.traceparent = val[0]
 		}
 
 		s.resourceSub = resourceSub
@@ -510,8 +517,14 @@ func (s *Subscription) addReference(rid string) (*Subscription, error) {
 		ref = refs[rid]
 	}
 
+	requestHeaders := make(map[string][]string)
+
+	if s.traceparent != "" {
+		requestHeaders["traceparent"] = []string{s.traceparent}
+	}
+
 	if ref == nil {
-		sub, err := s.c.Subscribe(rid, false, s.throttle)
+		sub, err := s.c.Subscribe(rid, false, s.throttle, requestHeaders)
 
 		if err != nil {
 			return nil, err

--- a/server/subscription.go
+++ b/server/subscription.go
@@ -200,9 +200,11 @@ func (s *Subscription) Loaded(resourceSub *rescache.ResourceSubscription, respon
 		}
 
 		// We check if we received a traceparent header in the response. If we did, we set it on the subscription.
-		val, ok := responseHeaders["traceparent"]
-		if ok && len(val) > 0 && s.traceparent == "" {
-			s.traceparent = val[0]
+		if responseHeaders != nil {
+			val, ok := responseHeaders["traceparent"]
+			if ok && len(val) > 0 && s.traceparent == "" {
+				s.traceparent = val[0]
+			}
 		}
 
 		s.resourceSub = resourceSub
@@ -519,6 +521,7 @@ func (s *Subscription) addReference(rid string) (*Subscription, error) {
 
 	requestHeaders := make(map[string][]string)
 
+	// If the subscription has a traceparent, add it to the subsiquent requests as a request header.
 	if s.traceparent != "" {
 		requestHeaders["traceparent"] = []string{s.traceparent}
 	}

--- a/test/natstest.go
+++ b/test/natstest.go
@@ -108,12 +108,12 @@ func (c *NATSTestClient) Close() {
 
 // SendRequest sends an asynchronous request on a subject, expecting the Response
 // callback to be called once.
-func (c *NATSTestClient) SendRequest(subj string, payload []byte, cb mq.Response) {
+func (c *NATSTestClient) SendRequest(subj string, payload []byte, cb mq.Response, requestHeaders map[string][]string) {
 	// Validate max control line size
 	// 7  = nats inbox prefix length
 	// 22 = nuid size
 	if len(subj)+7+22 > nats.MAX_CONTROL_LINE_SIZE {
-		go cb("", nil, mq.ErrSubjectTooLong)
+		go cb("", nil, nil, mq.ErrSubjectTooLong)
 		return
 	}
 
@@ -251,7 +251,7 @@ func (c *NATSTestClient) event(ns string, event string, payload interface{}) {
 	c.mu.Unlock()
 	subj := ns + "." + event
 	c.Tracef("=>> %s: %s", subj, data)
-	s.cb(subj, data, nil)
+	s.cb(subj, data, nil, nil)
 }
 
 // Unsubscribe removes the subscription.
@@ -323,14 +323,14 @@ func (r *Request) Respond(data interface{}) {
 // RespondRaw sends a raw byte response
 func (r *Request) RespondRaw(out []byte) {
 	r.c.Tracef("==> %s: %s", r.Subject, out)
-	r.getCallback()("__RESPONSE_SUBJECT__", out, nil)
+	r.getCallback()("__RESPONSE_SUBJECT__", out, nil, nil)
 }
 
 // SendError sends an error response
 func (r *Request) SendError(err error) {
 	cb := r.getCallback()
 	r.c.Tracef("X== %s: %s", r.Subject, err)
-	cb("", nil, err)
+	cb("", nil, nil, err)
 }
 
 // RespondSuccess sends a success response


### PR DESCRIPTION
When receiving a NATS header containing a `traceparent` id, we relay it to subsequent collection requests to allow the server application to correlate them.